### PR TITLE
Add 128 bit hasher (from klauspost PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x,1.19.x,1.20.x]
+        go-version: [1.22.x,1.23.x,1.24.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # v2.1.4
         with:
-          go-version: 1.20.x
+          go-version: 1.24.x
       - name: Checkout code
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/zeebo/xxh3
 
-go 1.17
+go 1.22
 
 require (
-	github.com/klauspost/cpuid/v2 v2.0.9
+	github.com/klauspost/cpuid/v2 v2.2.10
 	github.com/zeebo/assert v1.3.0
 )
+
+require golang.org/x/sys v0.30.0 // indirect
 
 replace github.com/zeebo/xxh3/avo => ./avo

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
-github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/hasher.go
+++ b/hasher.go
@@ -50,6 +50,23 @@ func (h *Hasher) Reset() {
 	h.len = 0
 }
 
+// ResetSeed will reset the hash and set a new seed.
+// This will change the original state used by Reset.
+func (h *Hasher) ResetSeed(seed uint64) {
+	h.Reset()
+	// Set key if not set before.
+	if h.seed == 0 && seed != 0 {
+		h.key = ptr(&[secretSize]byte{})
+	}
+	// Re-init seed.
+	if seed == 0 {
+		h.key = nil
+	} else if seed != h.seed {
+		initSecret(h.key, seed)
+	}
+	h.seed = seed
+}
+
 // BlockSize returns the hash's underlying block size.
 // The Write method will accept any amount of data, but
 // it may operate more efficiently if all writes are a

--- a/hasher128.go
+++ b/hasher128.go
@@ -1,0 +1,73 @@
+package xxh3
+
+import (
+	"hash"
+)
+
+// Hasher128 implements the hash.Hash interface.
+// It will return hashes that are 128 bits.
+type Hasher128 struct {
+	h Hasher
+}
+
+var (
+	_ hash.Hash = (*Hasher128)(nil)
+)
+
+// New128 returns a new 128 bit Hasher that implements the hash.Hash interface.
+func New128() *Hasher128 {
+	return &Hasher128{}
+}
+
+// NewSeed128 returns a new Hasher128 that implements the hash.Hash interface.
+func NewSeed128(seed uint64) *Hasher128 {
+	var h Hasher128
+	h.ResetSeed(seed)
+	return &h
+}
+
+// Reset resets the Hash to its initial state.
+func (h *Hasher128) Reset() {
+	h.h.Reset()
+}
+
+// ResetSeed will reset the hash and set a new seed.
+// This will change the original state used by Reset.
+func (h *Hasher128) ResetSeed(seed uint64) {
+	h.h.ResetSeed(seed)
+}
+
+// BlockSize returns the hash's underlying block size.
+// The Write method will accept any amount of data, but
+// it may operate more efficiently if all writes are a
+// multiple of the block size.
+func (h *Hasher128) BlockSize() int { return _stripe }
+
+// Size returns the number of bytes Sum will return.
+func (h *Hasher128) Size() int { return 16 }
+
+// Sum appends the current hash to b and returns the resulting slice.
+// It does not change the underlying hash state.
+func (h *Hasher128) Sum(b []byte) []byte {
+	sum := h.h.Sum128().Bytes()
+	return append(b, sum[:]...)
+}
+
+// Write adds more data to the running hash.
+// It never returns an error.
+func (h *Hasher128) Write(buf []byte) (int, error) {
+	h.h.update(buf)
+	return len(buf), nil
+}
+
+// WriteString adds more data to the running hash.
+// It never returns an error.
+func (h *Hasher128) WriteString(buf string) (int, error) {
+	h.h.updateString(buf)
+	return len(buf), nil
+}
+
+// Sum128 returns the 128-bit hash of the written data.
+func (h *Hasher128) Sum128() Uint128 {
+	return h.h.Sum128()
+}

--- a/internal/compare/go.mod
+++ b/internal/compare/go.mod
@@ -1,10 +1,15 @@
 module github.com/zeebo/xxh3/internal/compare
 
-go 1.12
+go 1.22
 
 require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/zeebo/xxh3 v0.0.0-20190706061215-e3a4ded7d14f
+)
+
+require (
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )
 
 replace github.com/zeebo/xxh3 => ../../

--- a/internal/compare/go.sum
+++ b/internal/compare/go.sum
@@ -2,7 +2,11 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-golang.org/x/sys v0.0.0-20200727154430-2d971f7391a4 h1:gtF+PUC1CD1a9ocwQHbVNXuTp6RQsAYt6tpi6zjT81Y=
-golang.org/x/sys v0.0.0-20200727154430-2d971f7391a4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
The Hasher returns size 8. Add a Hasher128 type that returns size 16.

Otherwise it is mostly just a wrapper around Hasher.

Adds `ResetSeed(uint64)` to both that allows re-use with a new seed.

Bumps dependencies, CI and min version to 1.22.